### PR TITLE
bypass OPTIONS request and auth header via GET method

### DIFF
--- a/drf_passwordless_jwt/tests.py
+++ b/drf_passwordless_jwt/tests.py
@@ -160,7 +160,7 @@ class TaskTest(APITestCase):
         )
         token = response.json()["token"]
 
-        response = self.client.post(
+        response = self.client.get(
             reverse("verify_jwt_token_header"),
             HTTP_AUTHORIZATION=f"Bearer {token}",
             format="json",
@@ -173,7 +173,7 @@ class TaskTest(APITestCase):
 
     @patch.dict(os.environ, {"EMAIL_TEST_ACCOUNT_a_at_a_com": "123456"})
     def test_verify_jwt_token_header_test_account(self):
-        response = self.client.post(
+        response = self.client.get(
             reverse("verify_jwt_token_header"),
             HTTP_AUTHORIZATION="Bearer anything",
             HTTP_X_EMAIL="a@a.com",
@@ -186,7 +186,7 @@ class TaskTest(APITestCase):
         self.assertEqual(json["email"], "a@a.com")
 
     def test_invalid_jwt_token_header(self):
-        response = self.client.post(
+        response = self.client.get(
             reverse("verify_jwt_token_header"),
             HTTP_AUTHORIZATION="Bearer badbeef",
             format="json",
@@ -195,7 +195,7 @@ class TaskTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_wrong_format_jwt_token_header(self):
-        response = self.client.post(
+        response = self.client.get(
             reverse("verify_jwt_token_header"),
             HTTP_AUTHORIZATION="badbeef",
             format="json",
@@ -204,7 +204,7 @@ class TaskTest(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_missing_jwt_token_header(self):
-        response = self.client.post(
+        response = self.client.get(
             reverse("verify_jwt_token_header"),
             format="json",
         )

--- a/drf_passwordless_jwt/views.py
+++ b/drf_passwordless_jwt/views.py
@@ -91,7 +91,11 @@ class VerifyJWTHeaderView(APIView):
     permission_classes = [AllowAny]
     serializer_class = JWTSerializer
 
-    def post(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):
+        request_method = request.headers.get("X-Forwarded-Method")
+        if request_method == "OPTIONS":
+            return Response(status=status.HTTP_200_OK)
+
         authorization_header = request.headers.get("Authorization")
 
         if not authorization_header:


### PR DESCRIPTION
将 apisix 使用的 token 校验方法改为 get，因为 apisix post会传递 body 浪费没必要
处理OPTIONS带不了 token导致401 的问题